### PR TITLE
fix: correct biocanda -> bioconda in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ to https://docs.conda.io/en/latest/miniconda.html to learn how to install conda
 on your system. Once conda is correctly installed. You need to install the
 crispron requirements with
 
-	conda create -y -c biocanda -c conda-forge --name crispron --file environment.yml
+	conda create -y -c bioconda -c conda-forge --name crispron --file environment.yml
 
 Later versions are also expected to work. However, the program depends on
 RNAfold and versions other than 2.2.5 of the ViennaRNA package will give


### PR DESCRIPTION
Fixes issue #5

Corrects the conda channel name from `biocanda` to `bioconda` in the README.md installation instructions.

`bioconda` is the correct conda-forge channel name for the Crispr analysis tools.